### PR TITLE
Fix broken links in Conferences component

### DIFF
--- a/src/app/conferences/page.tsx
+++ b/src/app/conferences/page.tsx
@@ -7,7 +7,7 @@ export default function Conferences() {
     <div className='flex flex-col'>
       <h2 className='mb-20 text-center'>Tekintsd meg korábbi konferenciáinkat:</h2>
       <div className='flex justify-between flex-col md:flex-row gap-10'>
-        <Link href='https://2023.konferencia.simonyi.bme.hu' target='blank'>
+        <Link href='https://2023.konferencia.simonyi.bme.hu' target='_blank'>
           <div className='flex flex-col justify-center items-center'>
             <Image src={'/img/xx.svg'} alt='XX. Simonyi Konferencia' width={200} height={96} />
             <div className='flex gap-2 items-center'>
@@ -16,7 +16,7 @@ export default function Conferences() {
             </div>
           </div>
         </Link>
-        <Link href='https://2022.konferencia.simonyi.bme.hu' target='blank'>
+        <Link href='https://2022.konferencia.simonyi.bme.hu' target='_blank'>
           <div className='flex flex-col justify-center items-center'>
             <Image src={'/img/xix.svg'} alt='XIX. Simonyi Konferencia' width={225} height={96} />
             <div className='flex gap-2 items-center'>
@@ -25,7 +25,7 @@ export default function Conferences() {
             </div>
           </div>
         </Link>
-        <Link href='https://2021.konferencia.simonyi.bme.hu' target='blank'>
+        <Link href='https://2021.konferencia.simonyi.bme.hu' target='_blank'>
           <div className='flex flex-col justify-center items-center'>
             <Image src={'/img/18.svg'} alt='18. Simonyi Konferencia' width={100} height={96} />
             <div className='flex gap-2 items-center'>


### PR DESCRIPTION
This PR fixes the broken links in the Conferences component by updating the target attribute of the Link elements to "_blank". Now, when the links are clicked, they will open in a new tab.